### PR TITLE
:seedling: Handle zones that are being deleted

### DIFF
--- a/pkg/providers/vsphere/placement/zone_placement.go
+++ b/pkg/providers/vsphere/placement/zone_placement.go
@@ -112,6 +112,10 @@ func getPlacementCandidates(
 			zones = append(zones, zone)
 		}
 		for _, zone := range zones {
+			// Filter out the zone that is to be deleted, so we don't have it as a candidate when doing placement.
+			if zonePlacement && !zone.DeletionTimestamp.IsZero() {
+				continue
+			}
 			rpMoIDs := zone.Spec.ManagedVMs.PoolMoIDs
 			if childRPName != "" {
 				childRPMoIDs := lookupChildRPs(vmCtx, vcClient, rpMoIDs, zone.Name, childRPName)

--- a/test/builder/dummies.go
+++ b/test/builder/dummies.go
@@ -40,6 +40,7 @@ const (
 	DummyStorageClassName  = "dummy-storage-class"
 	DummyResourceQuotaName = "dummy-resource-quota"
 	DummyZoneName          = "dummy-zone"
+	DummyDeletedZoneName   = "dummy-zone-deleted"
 )
 
 const (
@@ -91,13 +92,9 @@ func DummyNamedAvailabilityZone(name string) *topologyv1.AvailabilityZone {
 
 // DummyZone uses the same name with AZ.
 func DummyZone(namespace string) *topologyv1.Zone {
-	return DummyNamedZone(DummyZoneName, namespace)
-}
-
-func DummyNamedZone(name, namespace string) *topologyv1.Zone {
 	return &topologyv1.Zone{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      DummyZoneName,
 			Namespace: namespace,
 		},
 		Spec: topologyv1.ZoneSpec{},


### PR DESCRIPTION
**What does this PR do, and why is it needed?**
This patch handles Zones that are being deleted. We don't want to allow new VMs to be created in zones that are being deleted.
- If the VM specifies a zone at create time, validation webhook will reject the creation.
- If the VM specifies a valid zone at create time, it got deleted later, 
- For placement, filter out the to be drained zones so we don't have it as a candidate.
- If placement not needed, check if zone is being deleted before CreateGetFolderAndRPMoIDs.


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # N/A


**Are there any special notes for your reviewer**:
Testing done:
1. Bind 2 workload zones to supervisor, `zone-2` and `zone-3`.
2. Deploy VM with specified zone name places VM on expected zones.
3. Deploy 5 VMs with unspecified zone name, 4 landed on `zone-2` and 1 landed on `zone-3`
4. After `zone-2` deletion initiated
- VM deployment with specified `topology.kubernetes.io/zone: zone-2` is rejected.
```
Error from server (metadata.labels[topology.kubernetes.io/zone]: Invalid value: "zone-2": cannot use zone that is being deleted): error when creating "vm1.yaml": admission webhook "default.validating.virtualmachine.v1alpha3.vmoperator.vmware.com" denied the request: metadata.labels[topology.kubernetes.io/zone]: Invalid value: "zone-2": cannot use zone that is being deleted
```
- Deploy 5 VMs with unspecified zone name, all allocated to the remaining `zone-3` as expected.

*note*: I have to change `doesVMNeedPlacement`  because lint complained that Naked return statements should be used only in short functions.

**Please add a release note if necessary**:
```release-note
Zone Placement will ignore Zones that are being deleted under WCP_Workload_Domain_Isolation
```